### PR TITLE
fix: omit browser/dynamic-variant attrs when at defaults

### DIFF
--- a/mkdocs_likec4/parser.py
+++ b/mkdocs_likec4/parser.py
@@ -70,7 +70,9 @@ class LikeC4Parser:
             )
 
         tag = f"{opts.project.lower()}-view" if valid_project else "likec4-view"
-        return (
-            f'<{tag} view-id="{escape(opts.view_id, quote=True)}" '
-            f'browser="{opts.browser}" dynamic-variant="{opts.dynamic_variant}"></{tag}>'
-        )
+        attrs = f'view-id="{escape(opts.view_id, quote=True)}"'
+        if opts.browser != "true":
+            attrs += f' browser="{opts.browser}"'
+        if opts.dynamic_variant != "diagram":
+            attrs += f' dynamic-variant="{opts.dynamic_variant}"'
+        return f'<{tag} {attrs}></{tag}>'

--- a/mkdocs_likec4/parser.py
+++ b/mkdocs_likec4/parser.py
@@ -75,4 +75,4 @@ class LikeC4Parser:
             attrs += f' browser="{opts.browser}"'
         if opts.dynamic_variant != "diagram":
             attrs += f' dynamic-variant="{opts.dynamic_variant}"'
-        return f'<{tag} {attrs}></{tag}>'
+        return f"<{tag} {attrs}></{tag}>"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -251,28 +251,19 @@ class TestToHtml:
         """Test basic HTML output without project."""
         opts = ViewOptions(view_id="my-view")
         html = LikeC4Parser.to_html(opts)
-        assert (
-            html
-            == '<likec4-view view-id="my-view" browser="true" dynamic-variant="diagram"></likec4-view>'
-        )
+        assert html == '<likec4-view view-id="my-view"></likec4-view>'
 
     def test_html_with_project(self):
         """Test HTML output with valid project."""
         opts = ViewOptions(view_id="my-view", project="myproject")
         html = LikeC4Parser.to_html(opts)
-        assert (
-            html
-            == '<myproject-view view-id="my-view" browser="true" dynamic-variant="diagram"></myproject-view>'
-        )
+        assert html == '<myproject-view view-id="my-view"></myproject-view>'
 
     def test_html_with_uppercase_project(self):
         """Test HTML output with uppercase project (should be lowercased)."""
         opts = ViewOptions(view_id="my-view", project="MyProject")
         html = LikeC4Parser.to_html(opts)
-        assert (
-            html
-            == '<myproject-view view-id="my-view" browser="true" dynamic-variant="diagram"></myproject-view>'
-        )
+        assert html == '<myproject-view view-id="my-view"></myproject-view>'
 
     def test_html_with_custom_options(self):
         """Test HTML output with custom options."""
@@ -288,14 +279,25 @@ class TestToHtml:
             == '<proj-view view-id="test" browser="false" dynamic-variant="sequence"></proj-view>'
         )
 
+    def test_html_omits_only_default_browser(self):
+        """Only dynamic-variant is emitted when browser is at default."""
+        opts = ViewOptions(view_id="v", dynamic_variant="sequence")
+        html = LikeC4Parser.to_html(opts)
+        assert (
+            html == '<likec4-view view-id="v" dynamic-variant="sequence"></likec4-view>'
+        )
+
+    def test_html_omits_only_default_dynamic_variant(self):
+        """Only browser is emitted when dynamic-variant is at default."""
+        opts = ViewOptions(view_id="v", browser="false")
+        html = LikeC4Parser.to_html(opts)
+        assert html == '<likec4-view view-id="v" browser="false"></likec4-view>'
+
     def test_html_with_invalid_project_falls_back(self):
         """Test HTML output with invalid project name falls back to likec4-view."""
         opts = ViewOptions(view_id="my-view", project="123invalid")
         html = LikeC4Parser.to_html(opts)
-        assert (
-            html
-            == '<likec4-view view-id="my-view" browser="true" dynamic-variant="diagram"></likec4-view>'
-        )
+        assert html == '<likec4-view view-id="my-view"></likec4-view>'
 
     def test_html_escapes_invalid_view_id_with_quotes(self):
         """Test that invalid view ID with quotes is escaped to prevent XSS."""


### PR DESCRIPTION
The web component validates `browser` with ZodMiniBoolean. HTML attributes are always strings, so `getAttribute("browser")` returns "true" (string), which ZodMini rejects. `safeParse` fails and the component falls back to `{viewId: "index"}`, causing every diagram on the page to render the same view.

Omitting the attribute when it equals the default means `getAttribute` returns null, which the component converts to undefined via `?? void 0`, allowing Zod's own default to apply correctly.