### PR TITLE
fix: use shutil.which to resolve npx command location

### DIFF
--- a/mkdocs_likec4/generator.py
+++ b/mkdocs_likec4/generator.py
@@ -1,4 +1,5 @@
 import logging
+import shutil
 import subprocess
 from pathlib import Path
 from typing import Optional
@@ -55,7 +56,13 @@ class WebComponentGenerator:
             project_path,
         )
 
-        cmd = ["npx", "likec4", "codegen", "webcomponent"]
+        npx = shutil.which("npx")
+        if not npx:
+            log.error(
+                "mkdocs-likec4: 'npx' or 'likec4' command not found. "
+                "Ensure Node.js and likec4 are installed."
+            )
+        cmd = [npx, "likec4", "codegen", "webcomponent"]
         if not use_dot:
             cmd.append("--no-use-dot")
         if project_name is not None:

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -34,7 +34,8 @@ class TestGenerate:
     """Tests for the generate method."""
 
     @patch("mkdocs_likec4.generator.subprocess.run")
-    def test_generate_default_project(self, mock_run, tmp_path):
+    @patch("mkdocs_likec4.generator.shutil.which")
+    def test_generate_default_project(self, mock_which, mock_run, tmp_path):
         """Test generating web component for default project."""
         site_dir = tmp_path / "site"
         site_dir.mkdir()
@@ -46,10 +47,11 @@ class TestGenerate:
             site_dir=site_dir,
         )
 
+        mock_which.assert_called_once_with("npx")
         mock_run.assert_called_once()
         call_args = mock_run.call_args[0][0]
         call_kwargs = mock_run.call_args[1]
-        assert call_args[0] == "npx"
+        assert call_args[0] == mock_which.return_value
         assert call_args[1] == "likec4"
         assert call_args[2] == "codegen"
         assert call_args[3] == "webcomponent"

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,6 +1,7 @@
 """Tests for the LikeC4 plugin module."""
 
 import json
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -75,7 +76,7 @@ class TestDiscoverProjects:
         plugin._discover_projects(docs_dir)
 
         assert "nested" in plugin.project_map
-        assert plugin.project_map["nested"] == "sub/nested"
+        assert plugin.project_map["nested"] == str(Path("sub/nested"))
 
     def test_discover_no_projects_uses_default(self, plugin, docs_dir):
         """Test that no projects defaults to root project."""


### PR DESCRIPTION
Use `shutil.which` to resolve npx command path to fix #24
